### PR TITLE
test: stripes-erm-components translations

### DIFF
--- a/test/helpers/translationsProperties.js
+++ b/test/helpers/translationsProperties.js
@@ -1,5 +1,9 @@
 import { translationsProperties as coreTranslations } from '@folio/stripes-erm-testing';
 
+// Direct import is a bit gross, but so is exposing the translations file...
+// no super great way to do this so this will do for now.
+import ermTranslations from '@folio/stripes-erm-components/translations/stripes-erm-components/en.json';
+
 import translations from '../../translations/ui-service-interaction/en';
 
 const translationsProperties = [
@@ -7,36 +11,11 @@ const translationsProperties = [
     prefix: 'ui-service-interaction',
     translations,
   },
-  ...coreTranslations,
-/*   {
-    prefix: 'stripes-core',
-    translations: {
-      'label.missingRequiredField': 'Please fill this in to continue',
-      'button.save': 'Save',
-    }
-  },
   {
-    prefix: 'stripes-components',
-    translations: {
-      'saveAndClose': 'Save and close',
-      'cancel': 'Cancel',
-      'paneMenuActionsToggleLabel': 'Actions',
-      'collapseAll': 'Collapse all',
-      'button.edit': 'Edit'
-    },
+    prefix: 'stripes-erm-components',
+    translations: ermTranslations
   },
-  {
-    prefix: 'stripes-smart-components',
-    translations: {
-      'permissionError': 'Sorry - your permissions do not allow access to this page.',
-      'searchAndFilter': 'Search and filter',
-      'hideSearchPane': 'Hide search pane',
-      'search': 'Search',
-      'resetAll': 'Reset all',
-      'searchResultsCountHeader': '"{count, number} {count, plural, one {record found} other {records found}}"',
-      'new': 'New'
-    },
-  } */
+  ...coreTranslations
 ];
 
 export default translationsProperties;


### PR DESCRIPTION
stripes-erm-testing was previously exporting from stripes-erm-components, which would force a dev dep on stripes-erm-components in ALL implementing modules. This has now been removed, so each implementing module must provide its own translations from stripes-erm-components