### PR TITLE
feat: NumberGeneratorModal extra render

### DIFF
--- a/src/public/components/NumberGeneratorModal/NumberGeneratorModal.js
+++ b/src/public/components/NumberGeneratorModal/NumberGeneratorModal.js
@@ -16,6 +16,8 @@ const NumberGeneratorModal = forwardRef(({
   generator,
   generatorButtonProps,
   id,
+  renderTop,
+  renderBottom,
   ...modalProps
 }, ref) => {
   const { data: { results: data = [] } = {}, isLoading } = useNumberGenerators(generator);
@@ -106,6 +108,7 @@ const NumberGeneratorModal = forwardRef(({
       label={<FormattedMessage id="ui-service-interaction.numberGenerator.selectGenerator" />}
       {...modalProps}
     >
+      {renderTop ? renderTop() : null}
       <Select
         label={<FormattedMessage id="ui-service-interaction.numberGenerator.generator" />}
         onChange={(e) => {
@@ -131,6 +134,7 @@ const NumberGeneratorModal = forwardRef(({
         sequence={selectedSequence?.code ?? ''}
         {...generatorButtonProps}
       />
+      {renderBottom ? renderBottom() : null}
     </Modal>
   );
 });
@@ -144,6 +148,8 @@ NumberGeneratorModal.propTypes = {
   generator: PropTypes.string,
   generatorButtonProps: PropTypes.object,
   id: PropTypes.string.isRequired,
+  renderBottom: PropTypes.func,
+  renderTop: PropTypes.func,
 };
 
 export default NumberGeneratorModal;

--- a/src/public/components/NumberGeneratorModal/NumberGeneratorModal.test.js
+++ b/src/public/components/NumberGeneratorModal/NumberGeneratorModal.test.js
@@ -78,6 +78,7 @@ const testSelectOption = (numGen, seq, expected = true) => {
 };
 
 describe('NumberGeneratorModal', () => {
+  let renderedComponent;
   describe('NumberGeneratorModal with generator prop', () => {
     beforeEach(() => {
       renderWithIntl(
@@ -212,6 +213,29 @@ describe('NumberGeneratorModal', () => {
       test('passed callback gets called', () => {
         expect(callback.mock.calls.length).toBe(2);
       });
+    });
+  });
+
+  describe('NumberGeneratorModal with renderBottom/renderTop properties', () => {
+    beforeEach(() => {
+      renderedComponent = renderWithIntl(
+        <NumberGeneratorModal
+          renderBottom={() => <div>BOTTOM</div>}
+          renderTop={() => <div>TOP</div>}
+          {...NumberGeneratorModalPropsNoGenerator}
+        />,
+        translationsProperties
+      );
+    });
+
+    test('renders top', () => {
+      const { getByText } = renderedComponent;
+      expect(getByText('TOP')).toBeInTheDocument();
+    });
+
+    test('renders bottom', () => {
+      const { getByText } = renderedComponent;
+      expect(getByText('BOTTOM')).toBeInTheDocument();
     });
   });
 });

--- a/src/public/components/NumberGeneratorModal/README.md
+++ b/src/public/components/NumberGeneratorModal/README.md
@@ -43,4 +43,6 @@ id | String | A string to uniquely identify the Modal. Will result in an id `num
 generateButtonLabel | String/Node | An override for the label of the button rendered within the modal | "Generate" | ✕ |
 generator | String | The `code` for a given NumberGenerator set up in `ui-service-interaction`'s Settings panel. When not provided the Select will comprise of all sequences for all NumberGenerators fetched. | | ✕ |
 generatorButtonProps | object | An object containing button props to be passed onto the "generate" button within the modal. | | ✕ |
+renderBottom | function | A function which renders at the bottom of the modal, below the select(s) and generate button. | | ✕ |
+renderTop | function | A function which renders at the top of the modal, above the select(s). | | ✕ |
 ...modalProps | destructured object | Any other props passed to NumberGeneratorModal will be assumed to be modal props and passed directly on. Within these it is vital to provide an `open` and an `onClose` prop, as per the stripes-components Modal. | | ✕ |

--- a/src/public/components/NumberGeneratorModalButton/NumberGeneratorModalButton.js
+++ b/src/public/components/NumberGeneratorModalButton/NumberGeneratorModalButton.js
@@ -17,6 +17,8 @@ const NumberGeneratorModalButton = ({
   id,
   generatorButtonProps,
   modalProps,
+  renderBottom,
+  renderTop,
   ...buttonProps
 }) => {
   const modalButtonRef = useRef();
@@ -31,6 +33,8 @@ const NumberGeneratorModalButton = ({
       generator={generator}
       generatorButtonProps={generatorButtonProps}
       id={id}
+      renderBottom={renderBottom}
+      renderTop={renderTop}
       {...modalProps}
       {...mdProps}
     />
@@ -68,7 +72,9 @@ NumberGeneratorModalButton.propTypes = {
   generator: PropTypes.string,
   id: PropTypes.string.isRequired,
   generatorButtonProps: PropTypes.object,
-  modalProps: PropTypes.object
+  modalProps: PropTypes.object,
+  renderBottom: PropTypes.func,
+  renderTop: PropTypes.func,
 };
 
 export default NumberGeneratorModalButton;

--- a/src/public/components/NumberGeneratorModalButton/NumberGeneratorModalButton.test.js
+++ b/src/public/components/NumberGeneratorModalButton/NumberGeneratorModalButton.test.js
@@ -24,6 +24,8 @@ jest.mock('../NumberGeneratorModal', () => mockForwardRef(({
   generator: _generator,
   generatorButtonProps: _generatorButtonProps,
   id: _id,
+  renderBottom: _renderBottom,
+  renderTop: _renderTop,
   ...modalProps // grab modal props the same way we do in the actual component
 }, ref) => {
   return (

--- a/src/public/components/NumberGeneratorModalButton/README.md
+++ b/src/public/components/NumberGeneratorModalButton/README.md
@@ -33,5 +33,7 @@ generateButtonLabel | String/Node | An override for the label of the button rend
 generator | String | The `code` for a given NumberGenerator set up in `ui-service-interaction`'s Settings panel. When not provided the Select will comprise of all sequences for all NumberGenerators fetched. | | ✕ |
 generatorButtonProps | object | An object containing button props to be passed onto the "generate" button within the generator modal. | | ✕ |
 modalProps | object | An object containing any override props to be passed on to the NumberGeneratorModal | | ✕ |
+renderBottom | function | A function which renders at the bottom of the modal, below the select(s) and generate button. | | ✕ |
+renderTop | function | A function which renders at the top of the modal, above the select(s). | | ✕ |
 ...buttonProps | destructured object | Any other props passed to NumberGeneratorButton will be assumed to be button props for the trigger button and passed directly on. | | ✕ |
 


### PR DESCRIPTION
Added extra render props renderBottom and renderTop to NumberGeneratorModal to allow for rendering of extra information at the top/bottom of the modal for some use cases