### PR TITLE
TCR Review tweaks

### DIFF
--- a/src/settings/InfoPopovers/InfoPopovers.js
+++ b/src/settings/InfoPopovers/InfoPopovers.js
@@ -54,6 +54,8 @@ const OutputTemplateInfo = () => (
             buttonStyle="primary"
             href="https://wiki.folio.org/display/FOLIOtips/Output+templates"
             marginBottom0
+            rel="noreferrer"
+            target="blank"
           >
             <FormattedMessage id="ui-service-interaction.learnMore" />
           </Button>

--- a/src/settings/NumberGeneratorConfig.js
+++ b/src/settings/NumberGeneratorConfig.js
@@ -96,7 +96,11 @@ const NumberGeneratorConfig = ({
             id="ui-service-interaction.settings.numberGenerators.helpText"
             values={{
               helpDocumentationLink: (
-                <a href="https://wiki.folio.org/display/FOLIOtips/Number+generator">
+                <a
+                  href="https://wiki.folio.org/display/FOLIOtips/Number+generator"
+                  rel="noreferrer"
+                  target="_blank"
+                >
                   <FormattedMessage id="ui-service-interaction.settings.numberGenerators.helpDocumentationLink" />
                 </a>
               )

--- a/src/settings/NumberGeneratorSequenceConfig.js
+++ b/src/settings/NumberGeneratorSequenceConfig.js
@@ -113,6 +113,18 @@ const NumberGeneratorSequenceConfig = ({
     rowData.nextValue ?? 0
   ), []);
 
+  const renderName = useCallback((rowData) => {
+    return (
+      <Button
+        buttonStyle="link"
+        marginBottom0
+        onClick={() => setSelectedSequence(rowData)}
+      >
+        {rowData.name}
+      </Button>
+    );
+  }, []);
+
   return (
     <>
       <Pane
@@ -149,12 +161,12 @@ const NumberGeneratorSequenceConfig = ({
               }}
               contentData={sortedNumberGenSequences}
               formatter={{
+                name: renderName,
                 enabled: renderEnabled,
                 nextValue: renderNextValue,
               }}
               id="number-generator-sequences"
-              interactive
-              onRowClick={(_e, row) => { setSelectedSequence(row); }}
+              interactive={false}
               visibleColumns={['name', 'code', 'nextValue', 'enabled']}
             />
           }

--- a/src/settings/NumberGeneratorSequenceConfig.test.js
+++ b/src/settings/NumberGeneratorSequenceConfig.test.js
@@ -166,7 +166,8 @@ describe('NumberGeneratorSequenceConfig', () => {
 
   describe('Clicking a sequence', () => {
     beforeEach(async () => {
-      await MultiColumnList().click({ row: 0, column: 0 });
+      // This is now a button with the name of the sequence the user is selecting
+      await Button('sequence 1.1').click();
     });
 
     test('NumberGeneratorSequence gets rendered', () => {


### PR DESCRIPTION
feat: Tweaks

External help documentation links now open in a new tab, and the number generator sequences now conform to the UX pattern of first column link text instead of row click. (I still have misgivings about this as a pattern to adopt everywhere but it appears to be necessary to get through TCR)