### PR TITLE
SI-26: Link to documentation to open in a new tab

### DIFF
--- a/src/settings/InfoPopovers/InfoPopovers.js
+++ b/src/settings/InfoPopovers/InfoPopovers.js
@@ -52,7 +52,7 @@ const OutputTemplateInfo = () => (
           <Button
             allowAnchorClick
             buttonStyle="primary"
-            href="https://wiki.folio.org/display/FOLIOtips/Output+templates"
+            href="https://docs.folio.org/docs/settings/settings_service_interaction/settings_service_interaction"
             marginBottom0
             rel="noreferrer"
             target="blank"

--- a/src/settings/InfoPopovers/InfoPopovers.test.js
+++ b/src/settings/InfoPopovers/InfoPopovers.test.js
@@ -137,7 +137,7 @@ describe('InfoPopovers', () => {
 
     test('learn more button is rendered with correct href', async () => {
       await Button('Learn more').exists();
-      await Button('Learn more').has({ href: 'https://wiki.folio.org/display/FOLIOtips/Output+templates' });
+      await Button('Learn more').has({ href: 'https://docs.folio.org/docs/settings/settings_service_interaction/settings_service_interaction' });
     });
   });
 });

--- a/src/settings/NumberGeneratorConfig.js
+++ b/src/settings/NumberGeneratorConfig.js
@@ -97,7 +97,7 @@ const NumberGeneratorConfig = ({
             values={{
               helpDocumentationLink: (
                 <a
-                  href="https://wiki.folio.org/display/FOLIOtips/Number+generator"
+                  href="https://docs.folio.org/docs/settings/settings_service_interaction/settings_service_interaction/"
                   rel="noreferrer"
                   target="_blank"
                 >


### PR DESCRIPTION
chore: Link

Changed links to point to the future page `https://docs.folio.org/docs/settings/settings_service_interaction/settings_service_interaction/`

Fixed tests

SI-26