### PR TITLE
test: Test coverage for NumberGeneratorSelector

### DIFF
--- a/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.test.js
+++ b/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.test.js
@@ -1,16 +1,24 @@
-import { renderWithIntl } from '@folio/stripes-erm-testing';
+import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import { Button as MockButton, KeyValue as MockKeyValue } from '@folio/stripes/components';
+
+import { Button, Checkbox, KeyValue, renderWithIntl } from '@folio/stripes-erm-testing';
 
 import { translationsProperties } from '../../../../test/helpers';
-import { numberGenerator1, numberGenerator2 } from '../../../../test/jest/mockGenerators';
+import {
+  numberGenerator2,
+  numberGenerator3 as mockNumberGenerator3
+} from '../../../../test/jest/mockGenerators';
 
 import NumberGeneratorSelector from './NumberGeneratorSelector';
 
+
+/* ****** MOCKS ****** */
 const mockUseNumberGenerators = jest.fn((code) => {
   let generators = [];
   if (!code) {
-    generators = [numberGenerator1, numberGenerator2];
+    generators = [mockNumberGenerator3, numberGenerator2];
   } else {
-    generators = [numberGenerator1];
+    generators = [mockNumberGenerator3];
   }
 
   return ({
@@ -21,9 +29,12 @@ const mockUseNumberGenerators = jest.fn((code) => {
   });
 });
 
-const mockUseParallelBatchFetch = jest.fn(() => {
+const mockUseParallelBatchFetch = jest.fn(({ generateQueryKey }) => {
+  // Ensure generateQueryKey gets called for stupid coverage reasons
+  generateQueryKey({ batchParams: 'wibble', offset: 0 });
+
   return ({
-    items: [numberGenerator1, numberGenerator2].reduce((acc, curr) => {
+    items: [mockNumberGenerator3, numberGenerator2].reduce((acc, curr) => {
       const newAcc = [
         ...acc,
         ...curr.sequences.map(seq => ({
@@ -52,7 +63,7 @@ jest.mock('@folio/stripes-erm-components', () => {
   return ({
     ...ErmComps,
     ...mockErmComponents,
-    useParallelBatchFetch: () => mockUseParallelBatchFetch()
+    useParallelBatchFetch: (props) => mockUseParallelBatchFetch(props)
   });
 });
 // Perhaps typedown should have a proper interactor, if not for jest tests at least for cypress tests
@@ -63,20 +74,91 @@ jest.mock('@k-int/stripes-kint-components', () => {
   return ({
     ...KintComps,
     ...mockKintComponents,
-    QueryTypedown: ({ id }) => <div>{`QueryTypedown-${id}`}</div>
+    QueryTypedown: ({ id, input: { onChange, value }, renderFooter, renderListItem }) => {
+      return (
+        <div>
+          {`QueryTypedown-${id}`}
+          <MockKeyValue
+            label={`QueryTypedown-${id}-selected-option`}
+            value={value ? renderListItem(value, '') : 'Nothing selected'}
+          />
+          {mockNumberGenerator3.sequences.map(seq => {
+            return (
+              <MockButton
+                key={`QueryTypedown-${id}-option-${seq.id}`}
+                onClick={() => onChange(seq)}
+              >
+                {`QueryTypedown-${id}-option-${seq.id}`}
+              </MockButton>
+            );
+          })}
+          {renderFooter()}
+        </div>
+      );
+    }
   });
 });
 
 const mockOnSequenceChange = jest.fn();
+
+/* ****** PROPS ****** */
+
 
 const NumberGeneratorSelectorProps = {
   generator: 'numberGen1',
   onSequenceChange: mockOnSequenceChange
 };
 
-// This test is now remarkably small and ought to be improved to get test coverage up later...
+/* ****** REPEATED TESTS ****** */
+
+// Keep selected seq and rendered component globally available
+let seq;
+let renderedComponent;
+const renderSelectorAndSelectOptionFromSeqIndex = async (seqIndex, extraProps = {}) => {
+  seq = mockNumberGenerator3.sequences[seqIndex];
+
+  renderedComponent = renderWithIntl(
+    <NumberGeneratorSelector
+      selectFirstSequenceOnMount={false}
+      {...NumberGeneratorSelectorProps}
+      {...extraProps}
+    />,
+    translationsProperties
+  );
+
+  const expectedKeyValue = (seq.maximumCheck && (seq.maximumCheck.label === 'At maximum' || seq.maximumCheck.label === 'Over threshold')) ?
+    `${seq.name}·${seq.code}·Next value: ${seq.nextValue}·Usage status${seq.maximumCheck.label}` :
+    `${seq.name}·${seq.code}·Next value: ${seq.nextValue}`;
+
+  await waitFor(async () => {
+    await Button(`QueryTypedown-sequence_typedown-option-${seq.id}`).click();
+  });
+
+  await KeyValue('QueryTypedown-sequence_typedown-selected-option').has({ value: expectedKeyValue });
+};
+
+const warningText = '<strong>Warning:</strong> The number generator sequence <strong>{name}</strong> is approaching <strong>{maxVal}</strong>, its maximum value.';
+const testWarning = () => test('warning renders', () => {
+  const { getByText } = renderedComponent;
+  expect(getByText(warningText, { exact: false })).toBeInTheDocument();
+});
+const testNoWarning = () => test('warning does not render', () => {
+  const { queryByText } = renderedComponent;
+  expect(queryByText(warningText, { exact: false })).not.toBeInTheDocument();
+});
+
+const errorText = '<strong>Error:</strong> The number generator sequence <strong>{name}</strong> has reached <strong>{maxVal}</strong>, its maximum value. Please select a different sequence or contact your administrator.';
+const testError = () => test('error renders', () => {
+  const { getByText } = renderedComponent;
+  expect(getByText(errorText, { exact: false })).toBeInTheDocument();
+});
+const testNoError = () => test('error does not render', () => {
+  const { queryByText } = renderedComponent;
+  expect(queryByText(errorText, { exact: false })).not.toBeInTheDocument();
+});
+
+/* ****** TEST SUITE ****** */
 describe('NumberGeneratorSelector', () => {
-  let renderedComponent;
   describe('NumberGeneratorSelector with no id prop', () => {
     beforeEach(() => {
       renderedComponent = renderWithIntl(
@@ -87,18 +169,47 @@ describe('NumberGeneratorSelector', () => {
       );
     });
 
-    test('renders the query typedown', async () => {
+    test('renders the query typedown', () => {
       const { getByText } = renderedComponent;
       expect(getByText('QueryTypedown-sequence_typedown')).toBeInTheDocument();
     });
 
+    test('renders the query typedown footer', async () => {
+      await Checkbox({ id: 'includeAtMaxSequences_label' }).exists();
+      await Checkbox({ id: 'exact_match_label' }).exists();
+    });
+
+    describe('Selecting include max sequences checkbox', () => {
+      beforeEach(async () => {
+        await waitFor(async () => {
+          await Checkbox({ id: 'includeAtMaxSequences_label' }).click();
+        });
+      });
+
+      test('Include max sequences checkbox is checked', async () => {
+        await Checkbox({ id: 'includeAtMaxSequences_label' }).has({ checked: true });
+      });
+    });
+
+    describe('Selecting exact match checkbox', () => {
+      beforeEach(async () => {
+        await waitFor(async () => {
+          await Checkbox({ id: 'exact_match_label' }).click();
+        });
+      });
+
+      test('Include max sequences checkbox is checked', async () => {
+        await Checkbox({ id: 'exact_match_label' }).has({ checked: true });
+      });
+    });
+
     test('after load onSequenceChange is called with expected parameters', async () => {
       expect(mockOnSequenceChange).toHaveBeenCalledWith({
-        ...numberGenerator1.sequences[0],
+        ...mockNumberGenerator3.sequences[0],
         owner: {
-          code: numberGenerator1.code,
-          id: numberGenerator1.id,
-          name: numberGenerator1.name
+          code: mockNumberGenerator3.code,
+          id: mockNumberGenerator3.id,
+          name: mockNumberGenerator3.name
         }
       });
     });
@@ -136,6 +247,104 @@ describe('NumberGeneratorSelector', () => {
 
     test('after load onSequenceChange is not called', async () => {
       expect(mockOnSequenceChange).not.toHaveBeenCalled();
+    });
+
+    test('QueryTypedown KeyValue shows nothing selected', async () => {
+      await KeyValue('QueryTypedown-sequence_typedown-selected-option').has({ value: 'Nothing selected' });
+    });
+  });
+
+  describe('NumberGeneratorSelector display warnings', () => {
+    describe('default behaviour -- no warnings', () => {
+      const getTestFunc = (ind) => () => {
+        beforeEach(() => renderSelectorAndSelectOptionFromSeqIndex(ind));
+
+        testNoWarning();
+      };
+
+      describe('selecting sequence with no maximum check value', getTestFunc(0));
+      describe('selecting sequence with maximum check value "below_threshold"', getTestFunc(4));
+      describe('selecting sequence with maximum check value "over_threshold"', getTestFunc(5));
+      describe('selecting sequence with maximum check value "at_maximum"', getTestFunc(2));
+    });
+
+    describe('display warnings = false', () => {
+      const getTestFunc = (ind) => () => {
+        beforeEach(() => renderSelectorAndSelectOptionFromSeqIndex(ind, { displayWarning: false }));
+
+        testNoWarning();
+      };
+
+      describe('selecting sequence with no maximum check value', getTestFunc(0));
+      describe('selecting sequence with maximum check value "below_threshold"', getTestFunc(4));
+      describe('selecting sequence with maximum check value "over_threshold"', getTestFunc(5));
+      describe('selecting sequence with maximum check value "at_maximum"', getTestFunc(2));
+    });
+
+    describe('display warnings = true', () => {
+      const getTestFunc = (ind, expectWarning = false) => () => {
+        beforeEach(() => renderSelectorAndSelectOptionFromSeqIndex(ind, { displayWarning: true }));
+
+        if (expectWarning) {
+          testWarning();
+        } else {
+          testNoWarning();
+        }
+      };
+
+      describe('selecting sequence with no maximum check value', getTestFunc(0));
+      describe('selecting sequence with maximum check value "below_threshold"', getTestFunc(4));
+      describe('selecting sequence with maximum check value "over_threshold"', getTestFunc(5, true));
+      describe('selecting sequence with maximum check value "at_maximum"', getTestFunc(2));
+    });
+  });
+
+  describe('NumberGeneratorSelector display errors', () => {
+    describe('default behaviour -- errors on', () => {
+      const getTestFunc = (ind, expectError = false) => () => {
+        beforeEach(() => renderSelectorAndSelectOptionFromSeqIndex(ind));
+
+        if (expectError) {
+          testError();
+        } else {
+          testNoError();
+        }
+      };
+
+      describe('selecting sequence with no maximum check value', getTestFunc(0));
+      describe('selecting sequence with maximum check value "below_threshold"', getTestFunc(4));
+      describe('selecting sequence with maximum check value "over_threshold"', getTestFunc(5));
+      describe('selecting sequence with maximum check value "at_maximum"', getTestFunc(2, true));
+    });
+
+    describe('display errors = false', () => {
+      const getTestFunc = (ind) => () => {
+        beforeEach(() => renderSelectorAndSelectOptionFromSeqIndex(ind, { displayError: false }));
+
+        testNoError();
+      };
+
+      describe('selecting sequence with no maximum check value', getTestFunc(0));
+      describe('selecting sequence with maximum check value "below_threshold"', getTestFunc(4));
+      describe('selecting sequence with maximum check value "over_threshold"', getTestFunc(5));
+      describe('selecting sequence with maximum check value "at_maximum"', getTestFunc(2));
+    });
+
+    describe('display warnings = true', () => {
+      const getTestFunc = (ind, expectError = false) => () => {
+        beforeEach(() => renderSelectorAndSelectOptionFromSeqIndex(ind, { displayError: true }));
+
+        if (expectError) {
+          testError();
+        } else {
+          testNoError();
+        }
+      };
+
+      describe('selecting sequence with no maximum check value', getTestFunc(0));
+      describe('selecting sequence with maximum check value "below_threshold"', getTestFunc(4));
+      describe('selecting sequence with maximum check value "over_threshold"', getTestFunc(5));
+      describe('selecting sequence with maximum check value "at_maximum"', getTestFunc(2, true));
     });
   });
 });

--- a/test/jest/mockGenerators.js
+++ b/test/jest/mockGenerators.js
@@ -11,6 +11,16 @@ const getCheckDigitAlgoByValue = (val) => {
   };
 };
 
+const getMaximumCheckByValue = (val) => {
+  const { values, ...rdcRest } = refdata?.find(rdc => rdc?.desc === 'NumberGeneratorSequence.MaximumCheck');
+  const value = values?.find(rdv => rdv?.value === val);
+
+  return {
+    ...value,
+    owner: rdcRest
+  };
+};
+
 const numberGenerator1 = {
   id: 'number-generator-1',
   code: 'numberGen1',
@@ -99,7 +109,83 @@ const numberGenerator2 = {
   ]
 };
 
+const numberGenerator3 = {
+  id: '30f48059-b0b9-4434-8550-1aa12ea9b00f',
+  sequences: [
+    {
+      id: '352d11b6-095b-44d6-a053-b733a9c7510a',
+      code: 'b_test',
+      nextValue: 1,
+      name: 'B. Test',
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: true
+    },
+    {
+      id: 'aa0bf779-3622-4bae-8203-832824f599f8',
+      code: 'a_test',
+      nextValue: 1,
+      name: 'A. Test',
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: true
+    },
+    {
+      id: '559e4451-7209-4353-9ce1-6cc9de85d026',
+      code: 'efTest3',
+      nextValue: 101,
+      format: '###',
+      name: 'EF Test 3',
+      maximumNumber: 100,
+      maximumCheck: getMaximumCheckByValue('at_maximum'),
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: true
+    },
+    {
+      id: 'fb15ef2b-76c8-47ef-826d-f7cbb763d34a',
+      code: 'a_2_test',
+      nextValue: 1,
+      name: 'a. test',
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: false
+    },
+    {
+      id: '8c2bca3e-f677-4a9e-88e7-312eb8dd48dc',
+      code: 'eftest1',
+      nextValue: 50,
+      maximumNumberThreshold: 95,
+      format: '####',
+      name: 'EF Test 1',
+      maximumNumber: 100,
+      maximumCheck: getMaximumCheckByValue('below_threshold'),
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: true
+    },
+    {
+      id: '42d5c637-6294-4f76-9e97-9c5f3c787834',
+      code: 'efTest2',
+      nextValue: 95,
+      maximumNumberThreshold: 90,
+      format: '####',
+      name: 'EF Test 2',
+      maximumNumber: 100,
+      maximumCheck: getMaximumCheckByValue('over_threshold'),
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: true
+    },
+    {
+      id: '26b4378e-52d1-474d-b5d3-15af82ccd65d',
+      code: 'b_2_test',
+      nextValue: 1,
+      name: 'b. test',
+      checkDigitAlgo: getCheckDigitAlgoByValue('none'),
+      enabled: true
+    }
+  ],
+  code: 'ef_test_gen',
+  name: 'EF Test Gen'
+};
+
 export {
   numberGenerator1,
-  numberGenerator2
+  numberGenerator2,
+  numberGenerator3
 };

--- a/test/jest/refdata.js
+++ b/test/jest/refdata.js
@@ -62,6 +62,28 @@ const refdata = [
         label: 'EAN13'
       }
     ]
+  },
+  {
+    id: '2c9180908eabe9f4018eabf4ab1f0000',
+    desc: 'NumberGeneratorSequence.MaximumCheck',
+    internal: true,
+    values: [
+      {
+        id: '2c9180908eabe9f4018eabf4ab490002',
+        value: 'over_threshold',
+        label: 'Over threshold'
+      },
+      {
+        id: '2c9180908eabe9f4018eabf4ab370001',
+        value: 'below_threshold',
+        label: 'Below threshold'
+      },
+      {
+        id: '2c9180908eabe9f4018eabf4ab540003',
+        value: 'at_maximum',
+        label: 'At maximum'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Messive boost to coverage for NumberGeneratorSelector component, providing an example of how one might test a QueryTypedown (Or plain Typedown) component's utility as part of a larger suite of tests.