### PR TITLE
[FOLIO-4086] Fix GitHub Actions workflow not running for tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,6 +1,5 @@
-name: Centralized workflow test
+name: Centralized workflow
 on:
-  # todo: what would be best here?
   - push
   - pull_request
   - workflow_dispatch
@@ -9,6 +8,6 @@ jobs:
   ui:
     # Use the shared workflow from https://github.com/folio-org/.github
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    # Only handle push events from the main branch, to decrease noise
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    # Only handle push events from the main branch or tags, to decrease PR noise
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Code cleanup and test coverage
   * NumberGeneratorSelector: New exposed component NumberGeneratorSelector which was previously an internal implementation within NumberGeneratorModal. Now available for use in other implementations, with slightly expanded confiugurability and functionality.
   * Fixed Number Generator Sequence settings page not querying by all qIndices when all options are deselected (For stripes-erm-components versions including fix for ERM-3186)
+  * FOLIO-4086 Fix GitHub Actions workflow not running for tags
 
 ## 3.0.1 2024-04-09
   * SI-46: Number generator openAccess not considering sequence information output template and format


### PR DESCRIPTION
# [Jira FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086)

Due to an error in the [recommended configuration for shared workflows](https://github.com/folio-org/.github/blob/master/README-UI.md), an incorrect conditional was added to the workflow which can cause GitHub Actions to not run on tags, making it impossible to release this module.

This PR resolves this by adjusting the condition to always run the workflow for pushes to tags.

Also, I removed the `test` and `# todo` comments as those were similarly left in the recommended configuration by accident, and have no reason to remain.