### PR TITLE
SI-59 Number generator sequences - message banner when new sequences are saved - insert different token

### DIFF
--- a/src/settings/NumberGeneratorSequenceRoute/SequenceSearch.js
+++ b/src/settings/NumberGeneratorSequenceRoute/SequenceSearch.js
@@ -121,12 +121,12 @@ const SequenceSearch = ({
     post: addSeq,
   } = useMutateNumberGeneratorSequence({
     afterQueryCalls: {
-      post: (res) => {
+      post: (res, postData) => {
         setCreating(false);
         callout.sendCallout({
           message: <FormattedMessage
             id="ui-service-interaction.settings.numberGeneratorSequences.callout.create"
-            values={{ name: res.code }}
+            values={{ name: postData.name }}
           />
         });
 


### PR DESCRIPTION
fix: Sequence create correct callout information

On creating a new sequence currently the callout displays with the code of the generator, not the name of the sequence

SI-59