### PR TITLE
SI-108: Stripes v10 dependencies update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/service-interaction",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "FOLIO app for service-interaction",
   "main": "src/index.js",
   "repository": "folio-org/ui-service-interaction",
@@ -67,7 +67,7 @@
     ]
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^5.8.3",
+    "@k-int/stripes-kint-components": "^5.11.0",
     "dom-helpers": "^3.4.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
@@ -76,31 +76,29 @@
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/eslint-config-stripes": "^7.1.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-cli": "^3.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
     "@folio/stripes-erm-testing": "^3.0.0",
-    "@formatjs/cli": "^6.1.3",
+    "@formatjs/cli": "^6.6.0",
     "core-js": "^3.6.1",
     "eslint": "^7.32.0",
-    "moment": "^2.22.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.6.0",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.5.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
-    "moment": "^2.22.2",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
*BREAKING* Updated all stripes-* dependencies for the stripes v10 upgrade along with react-intl and formatjs/cli

Bumped version to 4.0.0

SI-108