### PR TITLE
SI-139: Add notice for missing permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * SI-134 Fix close button
   * SI-145 Add space character in callout message "numberGenerator.warning.sequenceHitMaximumWarning"
   * SI-146 Change links in help texts in Settings > Service interaction > Number generator sequences
+  * SI-139 Add notice when searching sequences in number generators modal without permissions
 
 ## 4.0.0 2024-03-13
   * SI-108 *BREAKING* Stripes v10 dependencies update

--- a/src/public/components/NumberGeneratorModal/NumberGeneratorModal.js
+++ b/src/public/components/NumberGeneratorModal/NumberGeneratorModal.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Button, Modal, ModalFooter } from '@folio/stripes/components';
+import { useStripes } from '@folio/stripes/core';
 
 import NumberGeneratorButton from '../NumberGeneratorButton';
 import NumberGeneratorSelector from '../NumberGeneratorSelector';
@@ -24,6 +25,8 @@ const NumberGeneratorModal = forwardRef(({
   ...modalProps
 }, ref) => {
   const [selectedSequence, setSelectedSequence] = useState();
+  const stripes = useStripes();
+  const hasPerms = stripes.hasPerm('ui-service-interaction.numberGenerator.view');
 
   return (
     <Modal
@@ -56,15 +59,20 @@ const NumberGeneratorModal = forwardRef(({
       label={<FormattedMessage id="ui-service-interaction.numberGenerator.selectGenerator" />}
       {...modalProps}
     >
-      {renderTop ? renderTop() : null}
-      <NumberGeneratorSelector
-        displayError={displayError}
-        displayWarning={displayWarning}
-        generator={generator}
-        onSequenceChange={(seq) => setSelectedSequence(seq)}
-        {...selectorProps}
-      />
-      {renderBottom ? renderBottom() : null}
+      {hasPerms ? (
+        <>
+          {renderTop ? renderTop() : null}
+          <NumberGeneratorSelector
+            displayError={displayError}
+            displayWarning={displayWarning}
+            generator={generator}
+            onSequenceChange={(seq) => setSelectedSequence(seq)}
+            {...selectorProps}
+          />
+          {renderBottom ? renderBottom() : null}
+        </>
+      ) : <FormattedMessage id="ui-service-interaction.numberGenerator.noPermission" />
+      }
     </Modal>
   );
 });

--- a/src/public/components/NumberGeneratorModal/NumberGeneratorModal.test.js
+++ b/src/public/components/NumberGeneratorModal/NumberGeneratorModal.test.js
@@ -1,6 +1,7 @@
 import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { Button as MockButton } from '@folio/stripes/components';
 import { Button } from '@folio/stripes-erm-testing';
+import { useStripes } from '@folio/stripes/core';
 
 import { renderWithTranslations } from '../../../../test/helpers';
 import {
@@ -43,7 +44,7 @@ const NumberGeneratorModalProps = {
 };
 
 // This test is now remarkably small and ought to be improved to get test coverage up later...
-describe('NumberGeneratorModal', () => {
+describe('NumberGeneratorModal - with permission', () => {
   let renderedComponent;
   describe('NumberGeneratorModal with generator prop', () => {
     beforeEach(() => {
@@ -96,5 +97,30 @@ describe('NumberGeneratorModal', () => {
         });
       });
     });
+  });
+});
+
+describe('NumberGeneratorModal - without permission', () => {
+  let renderedComponent;
+
+  beforeEach(() => {
+    useStripes.mockReturnValue({
+      hasPerm: jest.fn().mockReturnValue(false),
+    });
+    renderedComponent = renderWithTranslations(
+      <NumberGeneratorModal
+        {...NumberGeneratorModalProps}
+      />
+    );
+  });
+
+  test('renders noPermission message', () => {
+    const { getByText } = renderedComponent;
+    expect(getByText('You do not have the necessary permissions to use number generator sequences. Please contact your system administrator.')).toBeInTheDocument();
+  });
+
+  test('does not render the selector', () => {
+    const { queryByText } = renderedComponent;
+    expect(queryByText('NumberGeneratorSelector')).not.toBeInTheDocument();
   });
 });

--- a/translations/ui-service-interaction/en.json
+++ b/translations/ui-service-interaction/en.json
@@ -89,6 +89,7 @@
   "settings.numberGeneratorSequences.callout.create.error": "<strong>Error:</strong> Sequence <strong>{name}</strong> was not created. Check that the <strong>code</strong> is unique and try saving again. If this error recurs please contact your administrator.", 
   "numberGenerator.generateDisabledSequenceError": "This sequence is marked as disabled and cannot be generated from. Please contact a system admin",
   "numberGenerator.generate": "Generate",
+  "numberGenerator.noPermission": "You do not have the necessary permissions to use number generator sequences. Please contact your system administrator.",
   "numberGenerator.selectGenerator": "Select generator",
   "numberGenerator.generator": "Generator",
   "numberGenerator.warning": "<strong>Warning:</strong> The number was generated successfully but with an unspecified warning. It could be a temporary glitch. If this issue recurs please contact your administrator.",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/SI-139

### Description:

As a librarian I would like to know, when I don’t have the appropriate permission while using the number generator modal searching for sequences to generate numbers from. In addition to the _“no results found”_ within the search result list a notice somewhere in the modal or as callout _“You do not have the necessary permissions to use number generator sequences. Please contact your system administrator.”_ would be very helpful.

**Current**
When folio user does not have permission to use the number generator
- while searching for sequences in the modal _“User barcode generator”_ after clicking number generator button _“Generate user barcode”_
- the message is displayed _“no results found”_

**Expected**
When folio user does not have permission to use the number generator
- while searching for sequences in the modal _“User barcode generator”_ after clicking number generator button _“Generate user barcode”_
- the message is displayed “You do not have the necessary permissions to use number generator sequences. Please contact your system administrator.” as notice within the modal or as callout.

### Approach:

Since a user needs the permission **Settings (Service-interaction): View number generator settings and use number generators within apps** for seeing and selecting any sequence, a check depending on that permission has been added.
- If the **permission is available**, the **usual content of the Modal** will be rendered.
- If the **permission is not available**, the **message** _“You do not have the necessary permissions to use number generator sequences. Please contact your system administrator.”_ will be rendered as content of the Modal.