### PR TITLE
SI-165: Enable scroll functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.1.1 2026-05-28
   * Updated dependencies for Trillium release
+  * SI-165 Enable scroll functionality in NumberGeneratorSelector
 
 ## 4.1.0 2026-04-17
   * SI-94 Change Filter Usage status “No maximum set” to "No threshold set"

--- a/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.js
+++ b/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.js
@@ -83,6 +83,7 @@ const NumberGeneratorSelector = ({
 
   const [query, setQuery] = useState('');
 
+  // Since we're already fetching all sequences, we are using Typedown instead of QueryTypedown
   const { items: standaloneSequences, isLoading: isStandaloneSequencesFetching } = useParallelBatchFetch({
     batchParams: kiwtQueryParamOptions,
     endpoint: NUMBER_GENERATOR_SEQUENCES_ENDPOINT,

--- a/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.js
+++ b/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.js
@@ -7,8 +7,7 @@ import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
 
 import {
-  QueryTypedown,
-  generateKiwtQueryParams,
+  Typedown,
   highlightString
 } from '@k-int/stripes-kint-components';
 
@@ -63,14 +62,7 @@ const NumberGeneratorSelector = ({
   // Track "first mount" selection of first sequence
   const [selectFirstSequence, setSelectFirstSequence] = useState(selectFirstSequenceOnMount);
 
-  // Separate this out, so we know initial fetch will have same shape as queryTypedown does
-  // This will mean standalone won't know about any user facing queries, but that's fine
   const kiwtQueryParamOptions = useMemo(() => ({
-    ...(exactCodeMatch && {
-      filterKeys: {
-        code: 'code',
-      },
-    }),
     filters: [
       {
         path: 'enabled',
@@ -86,24 +78,26 @@ const NumberGeneratorSelector = ({
         value: '!(maximumCheck isNotNull&&maximumCheck.value==at_maximum)'
       }),
     ],
-    perPage: 10,
-    // Do not do match if exactCodeMatch is set
-    ...(!exactCodeMatch && {
-      searchKey: 'name,code',
-    }),
-    stats: false,
     sort: [{ path: 'owner.code' }, { path: 'name' }, { path: 'code' }],
-  }), [exactCodeMatch, generator, includeSequencesAtMaximum]);
+  }), [generator, includeSequencesAtMaximum]);
 
-  // We need extra call to ensure data integrity _after_selection.
-  // This will _only_ be used for updating after generation and initial population
+  const [query, setQuery] = useState('');
 
-  // Since we're already fetching all sequences, should we refactor from QueryTypedown to just Typedown?
   const { items: standaloneSequences, isLoading: isStandaloneSequencesFetching } = useParallelBatchFetch({
     batchParams: kiwtQueryParamOptions,
     endpoint: NUMBER_GENERATOR_SEQUENCES_ENDPOINT,
     generateQueryKey: ({ batchParams, offset }) => [NUMBER_GENERATOR_SEQUENCES_ENDPOINT, batchParams, offset, 'ui-service-interaction', 'useNumberGeneratorSequences']
   });
+
+  const filteredSequences = useMemo(() => {
+    if (!query) return standaloneSequences;
+    if (exactCodeMatch) {
+      return standaloneSequences.filter(s => s.code === query);
+    }
+    const regex = new RegExp(query.toLowerCase());
+    return standaloneSequences.filter(s => s.name?.toLowerCase().match(regex) ||
+      s.code?.toLowerCase().match(regex));
+  }, [exactCodeMatch, query, standaloneSequences]);
 
   const changeSelectedSequence = useCallback((seq) => {
     setSelectedSequence(seq);
@@ -214,20 +208,6 @@ const NumberGeneratorSelector = ({
 
     return undefined;
   };
-
-  const pathMutator = useCallback((input, path) => {
-    const queryParams = generateKiwtQueryParams(
-      kiwtQueryParamOptions,
-      {
-        query: input,
-        ...(exactCodeMatch && {
-          filters: `code.${input}`,
-        }),
-      }
-    );
-
-    return `${path}?${queryParams.join('&')}`;
-  }, [exactCodeMatch, kiwtQueryParamOptions]);
 
   const renderListItem = useCallback((sequence, input, _e, isSelected) => {
     const keyBase = `${uniqueId}-${sequence.id}`;
@@ -374,18 +354,18 @@ const NumberGeneratorSelector = ({
 
   return (
     <>
-      <QueryTypedown
+      <Typedown
+        dataOptions={filteredSequences}
         displayClearItem={false}
         endOfList={renderEndOFList()}
         id={uniqueId}
-        // To use this as a controlled component is currently a little fiddly, spoof an input object
         input={{
           name: uniqueId,
           onChange: (seq) => changeSelectedSequence(seq),
           value: selectedSequence
         }}
-        path={NUMBER_GENERATOR_SEQUENCES_ENDPOINT}
-        pathMutator={pathMutator}
+        // To use this as a controlled component is currently a little fiddly, spoof an input object
+        onType={(e) => setQuery(e.target.value)}
         renderFooter={renderTypedownFooter}
         renderListItem={renderListItem}
         {...queryTypedownProps}

--- a/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.js
+++ b/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.js
@@ -49,7 +49,7 @@ const NumberGeneratorSelector = ({
   onSequenceChange = noop,
   // Turn this off to render selector with no sequence selected automatically
   selectFirstSequenceOnMount = true,
-  ...queryTypedownProps
+  ...typedownProps
 }) => {
   const uniqueId = id ? SEQUENCE_TYPEDOWN_ID_UNIQUE(id) : SEQUENCE_TYPEDOWN_ID;
 
@@ -368,7 +368,7 @@ const NumberGeneratorSelector = ({
         onType={(e) => setQuery(e.target.value)}
         renderFooter={renderTypedownFooter}
         renderListItem={renderListItem}
-        {...queryTypedownProps}
+        {...typedownProps}
       />
       {renderWarningText()}
       {renderErrorText()}

--- a/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.test.js
+++ b/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.test.js
@@ -3,10 +3,10 @@ import {
   Button,
   Checkbox,
   KeyValue,
-  mockTypedownGetter,
 } from '@folio/stripes-erm-testing';
 
 import {
+  numberGenerator1,
   numberGenerator2,
   numberGenerator3 as mockNumberGenerator3
 } from '../../../../test/jest/mockGenerators';
@@ -69,15 +69,58 @@ jest.mock('@folio/stripes-erm-components', () => {
     useParallelBatchFetch: (props) => mockUseParallelBatchFetch(props)
   });
 });
-// Perhaps typedown should have a proper interactor, if not for jest tests at least for cypress tests
+
 jest.mock('@k-int/stripes-kint-components', () => {
+  const { useState } = jest.requireActual('react');
   const { mockKintComponents } = jest.requireActual('@folio/stripes-erm-testing');
   const KintComps = jest.requireActual('@k-int/stripes-kint-components');
+  const {
+    Button: FactoryButton,
+    KeyValue: FactoryKeyValue,
+    TextField: FactoryTextField,
+  } = jest.requireActual('@folio/stripes/components');
+
+  const MockTypedown = ({
+    id,
+    input: { onChange, value },
+    onType,
+    dataOptions = [],
+    renderFooter = () => {},
+    renderListItem,
+  }) => {
+    const [typed, setTyped] = useState('');
+    return (
+      <div>
+        {`Typedown-${id}`}
+        <FactoryTextField
+          label={`Typedown-${id}-textfield`}
+          onChange={e => {
+            if (onType) onType(e);
+            setTyped(e.target.value);
+          }}
+          value={typed}
+        />
+        <FactoryKeyValue
+          label={`Typedown-${id}-selected-option`}
+          value={value ? renderListItem(value, '') : 'Nothing selected'}
+        />
+        {dataOptions.map(seq => (
+          <FactoryButton
+            key={`Typedown-${id}-option-${seq.id}`}
+            onClick={() => onChange(seq)}
+          >
+            {`Typedown-${id}-option-${seq.id}`}
+          </FactoryButton>
+        ))}
+        {renderFooter()}
+      </div>
+    );
+  };
 
   return ({
     ...KintComps,
     ...mockKintComponents,
-    QueryTypedown: mockTypedownGetter(mockNumberGenerator3.sequences)
+    Typedown: MockTypedown,
   });
 });
 
@@ -177,6 +220,30 @@ describe('NumberGeneratorSelector', () => {
       } else {
         await KeyValue(`${typedownGetterString}-selected-option`).has({ value: 'Nothing selected' });
       }
+    });
+  });
+
+  describe('NumberGeneratorSelector displays all sequences (no perPage limit)', () => {
+    const allSequences = [mockNumberGenerator3, numberGenerator2, numberGenerator1].flatMap(gen => gen.sequences.map(s => ({ ...s, owner: { id: gen.id, name: gen.name, code: gen.code } })));
+
+    beforeEach(() => {
+      mockUseParallelBatchFetch.mockImplementationOnce(({ generateQueryKey }) => {
+        generateQueryKey({ batchParams: 'wibble', offset: 0 });
+        return { items: allSequences, isLoading: false };
+      });
+
+      renderedComponent = renderWithTranslations(
+        <NumberGeneratorSelector
+          {...NumberGeneratorSelectorProps}
+          selectFirstSequenceOnMount={false}
+        />,
+      );
+    });
+
+    test(`all ${allSequences.length} sequences are rendered as selectable options`, () => {
+      const { getAllByText } = renderedComponent;
+      const options = getAllByText(/^Typedown-sequence_typedown-option-/);
+      expect(options).toHaveLength(allSequences.length);
     });
   });
 

--- a/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.test.js
+++ b/src/public/components/NumberGeneratorSelector/NumberGeneratorSelector.test.js
@@ -16,22 +16,6 @@ import { renderWithTranslations } from '../../../../test/helpers';
 
 
 /* ****** MOCKS ****** */
-const mockUseNumberGenerators = jest.fn((code) => {
-  let generators = [];
-  if (!code) {
-    generators = [mockNumberGenerator3, numberGenerator2];
-  } else {
-    generators = [mockNumberGenerator3];
-  }
-
-  return ({
-    data: {
-      results: generators
-    },
-    isLoading: false
-  });
-});
-
 const mockUseParallelBatchFetch = jest.fn(({ generateQueryKey }) => {
   // Ensure generateQueryKey gets called for stupid coverage reasons
   generateQueryKey({ batchParams: 'wibble', offset: 0 });
@@ -54,10 +38,6 @@ const mockUseParallelBatchFetch = jest.fn(({ generateQueryKey }) => {
     isLoading: false
   });
 });
-
-jest.mock('../../hooks', () => ({
-  useNumberGenerators: (code) => mockUseNumberGenerators(code)
-}));
 
 jest.mock('@folio/stripes-erm-components', () => {
   const { mockErmComponents } = jest.requireActual('@folio/stripes-erm-testing');
@@ -214,7 +194,7 @@ describe('NumberGeneratorSelector', () => {
       }
     });
 
-    test('QueryTypedown KeyValue shows expected value', async () => {
+    test('Typedown KeyValue shows expected value', async () => {
       if (componentProps.selectFirstSequenceOnMount !== false) {
         await KeyValue(`${typedownGetterString}-selected-option`).has({ value: getTypedownLabelFromSequence(mockNumberGenerator3.sequences[0]) });
       } else {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/SI-165


### Description

**current**

Scroll bar is visible in Generate modal (number generators), but due to a default setting of ten the first ten entries are displayed and the scroll functionality cannot be used. (Please see screenshots)

This applies to all Generate modals in Receiving, Inventory, Organizations, Users

Example Generate call number in Inventory > Holdings

<img width="400" alt="grafik-20260526-154907" src="https://github.com/user-attachments/assets/77f6e95b-926e-4105-9590-496a6077ec5f" />



Example Receiving (Modal combined for Call number, Accession number and/or item barcode)


<img width="400"  alt="grafik-20260526-154941" src="https://github.com/user-attachments/assets/decf62f3-32cf-42ce-addb-1f22dbe0a948" />

**expected**

the scroll functionality can be used to scroll all sequences.



### Problem

- `NumberGeneratorSelector` uses `QueryTypedown` to display sequences in a dropdown. `QueryTypedown` fetches results server-side on every keystroke, limited by the `perPage` parameter.
With `perPage: 10` **only the first 10 results were returned — there was no way to scroll to results beyond that limit**.
- At the same time, `useParallelBatchFetch` was already fetching all sequences (in batches of up to 100). 

→ This means two separate API calls were made for the same data.

### Solution

- Replaced `QueryTypedown` with `Typedown`, passing the (already) loaded sequences directly as `dataOptions`. 
- Client-side filtering is handled via an `onType` handler and a `filteredSequences` function:
   - **Default mode**: filters by `name` OR `code` 
   - **exact code match mode**: filters by `exactCodeMatch`

→ Duplicate API calls will be eliminated entirely. All sequences are available for scrolling as soon as the initial batch fetch completes.
The `perPage`, `stats`, `searchKey`, and `filterKeys` fields were removed since they were only relevant for the server-side search path and are no longer needed.