### PR TITLE
SI-173: Duplicate sequenc: Show callout if code is already used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.2.0 IN PROGRESS
   * SI-172 Add Duplicate of Sequences for number generator sequences in settings
   * SI-151 Enable dynamic ${current_year} token in number generator output templates
+  * SI-173 Duplicate sequence: Show callout if using non unique code
 
 ## 4.1.1 2026-05-28
   * Updated dependencies for Trillium release

--- a/src/settings/NumberGeneratorSequenceRoute/SequenceView/SequenceView.js
+++ b/src/settings/NumberGeneratorSequenceRoute/SequenceView/SequenceView.js
@@ -87,6 +87,21 @@ const NumberGeneratorSequence = ({
         onClose();
       },
     },
+    catchQueryCalls: {
+      // Catch post error here instead of in onError of FormModal as we have access to postData here
+      post: (err, postData) => {
+        callout.sendCallout({
+          type: 'error',
+          message: <FormattedMessage
+            id="ui-service-interaction.settings.numberGeneratorSequences.callout.create.error"
+            values={{ name: postData.code, err: err.message }}
+          />
+        });
+
+        // FormModal needs errors rethrown to avoid restarting form
+        throw err;
+      }
+    },
     id: sequence?.owner?.id
   });
 

--- a/src/settings/NumberGeneratorSequenceRoute/SequenceView/SequenceView.test.js
+++ b/src/settings/NumberGeneratorSequenceRoute/SequenceView/SequenceView.test.js
@@ -15,13 +15,23 @@ const mockSequence = numberGenerator1?.sequences[0];
 const mockGenerators = [numberGenerator1, numberGenerator2];
 
 const fakeCalloutInfo = { id: '123', label: 'numgenName', code: 'numgenCode' };
+const fakeError = { message: 'Duplicate code' };
+
+// Controls whether the mocked `post` mutation (used for duplicating a sequence) resolves or rejects
+let mockShouldPostFail = false;
 
 jest.mock('../../../public', () => ({
   ...jest.requireActual('../../../public'),
   useNumberGeneratorSequence: jest.fn(() => ({ data: mockSequence })),
-  useMutateNumberGeneratorSequence: ({ afterQueryCalls: { delete: deleteQueryCalls, put: putQueryCalls, post: postQueryCalls } }) => ({
+  useMutateNumberGeneratorSequence: ({
+    afterQueryCalls: { delete: deleteQueryCalls, put: putQueryCalls, post: postQueryCalls },
+    catchQueryCalls: { post: postCatchQueryCalls } = {},
+  }) => ({
     put: () => Promise.resolve(true).then(() => putQueryCalls(mockGenerators[0], fakeCalloutInfo)),
-    post: () => Promise.resolve(true).then(() => postQueryCalls(mockGenerators[0], fakeCalloutInfo)),
+    post: () => (mockShouldPostFail
+      ? Promise.resolve().then(() => postCatchQueryCalls(fakeError, fakeCalloutInfo))
+      : Promise.resolve(true).then(() => postQueryCalls(mockGenerators[0], fakeCalloutInfo))
+    ),
     delete: () => Promise.resolve(true).then(() => deleteQueryCalls()),
   }),
 }));
@@ -66,6 +76,8 @@ jest.mock('../NumberGeneratorSequenceForm', () => () => {
 let renderComponent;
 describe('SequenceView', () => {
   beforeEach(async () => {
+    mockShouldPostFail = false;
+    onClose.mockClear();
     renderComponent = renderWithTranslations(
       <SequenceView
         match={{ params: { seqId: mockSequence?.id } }}
@@ -202,6 +214,29 @@ describe('SequenceView', () => {
         test('onClose is called, returning to the sequence list', async () => {
           await waitFor(() => {
             expect(onClose).toHaveBeenCalled();
+          });
+        });
+      });
+
+      describe('saving the duplicate with a code that is already taken', () => {
+        beforeEach(async () => {
+          mockShouldPostFail = true;
+          await waitFor(async () => {
+            await TextField('TEST FIELD').fillIn('new name');
+            await TextField('TEST FIELD CODE').fillIn('existing-code');
+            await Button('Save & close').click();
+          });
+        });
+
+        test('error callout fires instead of the success callout', async () => {
+          await waitFor(async () => {
+            await Callout('<strong>Error:</strong> Sequence <strong>{name}</strong> was not created. Check that the <strong>code</strong> is unique and try saving again. If this error recurs please contact your administrator.').exists();
+          });
+        });
+
+        test('the modal stays open with the entered values (form is not reset)', async () => {
+          await waitFor(async () => {
+            await TextField('TEST FIELD CODE').has({ value: 'existing-code' });
           });
         });
       });


### PR DESCRIPTION
[SI-173](https://folio-org.atlassian.net/browse/SI-173)

### Description

**Duplicate sequenc: Show callout if code is already used**

Settings > Service interaction > Number generator sequences > Action: Duplicate
- fill in a name
- fill in a code, which is already used in another sequence
- click “save & close“

**Actual result:**
The field values filled in manually are empty (name and code)

**Expected result:**
The same callout should be visible which is showing if a new sequence is created:

### Approach

- Add `catchQueryCalls.post` handler that shows an **error callout** on failure (instead of failing silently).
- Throw the error afterward so `FormModal` doesn't reset the form.
- Added an extra test asserting that the entered form values are preserved on failure and the callout is showing.